### PR TITLE
Update default user agent to include "purviewcli/<version>"

### DIFF
--- a/purviewcli/client/client.py
+++ b/purviewcli/client/client.py
@@ -72,7 +72,8 @@ Alternatively, an Azure Purview account name can be provided by appending --purv
             uri = f"https://{self.account_name}.{app}.purview.azure.com{endpoint}"
 
         auth = {"Authorization": "Bearer {0}".format(self.access_token)}
-        headers = dict(**headers, **auth)
+        useragent = {"User-Agent": "purviewcli {0}".format(requests.utils.default_headers().get("User-Agent"))}
+        headers = dict(**headers, **auth, **useragent)
 
         try:
             response = requests.request(method, uri, params=params, json=payload, files=files, headers=headers)

--- a/purviewcli/client/client.py
+++ b/purviewcli/client/client.py
@@ -7,6 +7,7 @@ from http.client import responses
 from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import ClientAuthenticationError
 from . import settings
+from .. import __version__
 
 logging.getLogger("azure.identity").setLevel(logging.ERROR)
 
@@ -72,7 +73,7 @@ Alternatively, an Azure Purview account name can be provided by appending --purv
             uri = f"https://{self.account_name}.{app}.purview.azure.com{endpoint}"
 
         auth = {"Authorization": "Bearer {0}".format(self.access_token)}
-        useragent = {"User-Agent": "purviewcli {0}".format(requests.utils.default_headers().get("User-Agent"))}
+        useragent = {"User-Agent": "purviewcli/{0} {1}".format(__version__, requests.utils.default_headers().get("User-Agent"))}
         headers = dict(**headers, **auth, **useragent)
 
         try:


### PR DESCRIPTION
Update default user agent to include `purviewcli/<version>` to indicate requests are sent using which `purviewcli` version.

before
```
'User-Agent': 'python-requests/2.25.1'
```
after
```
'User-Agent': 'purviewcli/0.3.0 python-requests/2.25.1'
```